### PR TITLE
Add initial pydantic model

### DIFF
--- a/src/styx/frontend/schema/__init__.py
+++ b/src/styx/frontend/schema/__init__.py
@@ -1,0 +1,7 @@
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+StringProperty = Annotated[str, StringConstraints(min_length=1)]
+
+__all__ = ["StringProperty"]

--- a/src/styx/frontend/schema/descriptors_schema.py
+++ b/src/styx/frontend/schema/descriptors_schema.py
@@ -1,0 +1,107 @@
+from typing import Annotated, Any, Literal, Optional, Union
+
+import pydantic
+
+from . import StringProperty, properties
+
+
+class Descriptor(pydantic.BaseModel):
+    """Complete Descriptor JSON schema model."""
+
+    model_config = pydantic.ConfigDict(
+        populate_by_name=True, extra="forbid", validate_assignment=True
+    )
+
+    # Required fields
+    name: StringProperty = pydantic.Field(description="Tool name.")
+    description: StringProperty = pydantic.Field(description="Tool description.")
+    tool_version: StringProperty = pydantic.Field(
+        alias="tool-version", description="Tool version."
+    )
+    command_line: str = pydantic.Field(
+        alias="command-line",
+        description='A string that describes the tool command line, where input and output values are identified by "keys". At runtime, command-line keys are substituted with flags and values.',
+    )
+    schema_version: Literal["0.5"] = pydantic.Field(alias="schema-version")
+    inputs: list[properties.Input] = pydantic.Field(
+        description="An array of input objects", min_length=1
+    )
+
+    # Optional fields
+    deprecated_by_doi: Optional[Union[StringProperty, bool]] = pydantic.Field(
+        alias="deprecated-by-doi",
+        description="doi of the tool that deprecates the current one. May be set to 'true' if the current tool is deprecated but no specific tool deprecates it.",
+        default=None,
+    )
+    author: Optional[StringProperty] = pydantic.Field(
+        description="Tool author name(s).", default=None
+    )
+    url: Optional[StringProperty] = pydantic.Field(
+        description="Tool URL.", default=None
+    )
+    descriptor_url: Optional[StringProperty] = pydantic.Field(
+        alias="descriptor-url",
+        description="Link to the descriptor itself (e.g. the GitHub repo where it is hosted).",
+        default=None,
+    )
+    doi: Optional[StringProperty] = pydantic.Field(
+        description="DOI of the descriptor (not of the tool itself).", default=None
+    )
+    shell: Optional[StringProperty] = pydantic.Field(
+        description="Absolute path of the shell interpreter to use in the container (defaults to /bin/sh).",
+        default=None,
+    )
+    tool_doi: Optional[StringProperty] = pydantic.Field(
+        alias="tool-doi",
+        description="DOI of the tool (not of the descriptor).",
+        default=None,
+    )
+    container_image: Optional[properties.ContainerImage] = pydantic.Field(
+        alias="container-image", default=None
+    )
+    environment_variables: Optional[list[properties.EnvironmentVariable]] = (
+        pydantic.Field(
+            alias="environment-variables",
+            description="An array of key-value pairs specifying environment variable names and their values to be used in the execution environment.",
+            default=None,
+        )
+    )
+    groups: Optional[list[properties.Group]] = pydantic.Field(
+        description="Sets of identifiers of inputs, each specifying an input group.",
+        default=None,
+        min_length=1,
+    )
+    tests: Optional[list[properties.TestCase]] = pydantic.Field(
+        default=None, min_length=1
+    )
+    online_platform_urls: Optional[
+        Annotated[str, pydantic.StringConstraints(pattern=r"^https?://")]
+    ] = pydantic.Field(
+        alias="online-platform-urls",
+        description="Online platform URLs from which the tool can be executed.",
+        default=None,
+    )
+    output_files: Optional[list[properties.Output]] = pydantic.Field(
+        alias="output-files", default=None, min_length=1
+    )
+    suggested_resources: Optional[properties.SuggestedResources] = pydantic.Field(
+        alias="suggested-resources", default=None, min_length=1
+    )
+    tags: Optional[dict[str, Union[str, list[str], bool]]] = pydantic.Field(
+        description="A set of key-value pairs specifying tags describing the pipeline. The tag names are open, they might be more constrained in the future.",
+        default=None,
+    )
+    error_codes: Optional[list[properties.ErrorCode]] = pydantic.Field(
+        alias="error-codes",
+        description="An array of key-value pairs specifying exit codes and their description. Can be used for tools to specify the meaning of particular exit codes. Exit code 0 is assumed to indicate a successful execution.",
+        min_length=1,
+        default=None,
+    )
+    custom: Optional[dict[str, Any]] = None
+
+    @pydantic.model_validator(mode="after")
+    def validate_descriptor(self):
+        """Additional validation for the entire descriptor."""
+        if self.schema_version != "0.5":
+            raise ValueError("Only schema version 0.5 is supported")
+        return self

--- a/src/styx/frontend/schema/properties/__init__.py
+++ b/src/styx/frontend/schema/properties/__init__.py
@@ -1,0 +1,18 @@
+from .containers import ContainerImage
+from .environment import EnvironmentVariable
+from .errors import ErrorCode
+from .groups import Group
+from .io import Input, Output
+from .resources import SuggestedResources
+from .tests import TestCase
+
+__all__ = [
+    "ContainerImage",
+    "EnvironmentVariable",
+    "ErrorCode",
+    "SuggestedResources",
+    "TestCase",
+    "Group",
+    "Input",
+    "Output",
+]

--- a/src/styx/frontend/schema/properties/containers.py
+++ b/src/styx/frontend/schema/properties/containers.py
@@ -1,0 +1,56 @@
+from typing import Literal, Optional, Self
+
+import pydantic
+
+from .. import StringProperty
+
+
+class ContainerImage(pydantic.BaseModel):
+    """Model for container image configuration."""
+
+    type_: Literal["docker", "singularity", "rootfs"] = pydantic.Field(alias="type")
+    image: Optional[StringProperty] = pydantic.Field(
+        description="Name of an image where the tool is installed and configured. Example: bids/mriqc.",
+        default=None,
+    )
+    url: Optional[StringProperty] = pydantic.Field(
+        description="URL where the image is available.", default=None
+    )
+    working_directory: Optional[StringProperty] = pydantic.Field(
+        alias="working-directory",
+        description="Location from which this task must be launched within the container.",
+        default=None,
+    )
+    container_hash: Optional[StringProperty] = pydantic.Field(
+        alias="container-hash",
+        description="Hash for the given container.",
+        default=None,
+    )
+    entrypoint: bool = pydantic.Field(
+        description="Flag indicating whether or not the container uses an entrypoint.",
+        default=False,
+    )
+    index: Optional[StringProperty] = pydantic.Field(
+        description="Optional index where the image is available, if not the standard location. Example: docker.io",
+        default=None,
+    )
+    container_opts: Optional[list[str]] = pydantic.Field(
+        alias="container-opts",
+        description="Container-level arguments for the application. Example: --privileged",
+        default=None,
+    )
+
+    @pydantic.model_validator(mode="after")
+    def validate_container_properties(self) -> Self:
+        error_messages = {
+            "rootfs": "'url' parameter must be provided for container type 'rootfs'",
+            "docker": "'image' parameter must be provided for container type 'docker'",
+            "singularity": "'image' parameter must be provided for container type 'singularity'",
+        }
+
+        if (self.type_ == "rootfs" and self.url is None) or (
+            self.type_ in ["docker", "singularity"] and self.image is None
+        ):
+            raise ValueError(error_messages[self.type_])
+
+        return self

--- a/src/styx/frontend/schema/properties/environment.py
+++ b/src/styx/frontend/schema/properties/environment.py
@@ -1,0 +1,18 @@
+from typing import Annotated, Optional
+
+import pydantic
+
+
+class EnvironmentVariable(pydantic.BaseModel):
+    """Model for environment variables."""
+
+    name: Annotated[
+        str,
+        pydantic.StringConstraints(pattern=r"^[a-zA-Z][0-9_a-zA-Z]*$", min_length=1),
+    ] = pydantic.Field(
+        description='The environment variable name (identifier) containing only alphanumeric characters and underscores. Example: "PROGRAM_PATH".',
+    )
+    value: str = pydantic.Field(description="The value of the environment variable.")
+    description: Optional[str] = pydantic.Field(
+        description="Description of the environment variable.", default=None
+    )

--- a/src/styx/frontend/schema/properties/errors.py
+++ b/src/styx/frontend/schema/properties/errors.py
@@ -1,0 +1,8 @@
+import pydantic
+
+
+class ErrorCode(pydantic.BaseModel):
+    """Model for error codes."""
+
+    code: int = pydantic.Field(description="Value of the exit code")
+    description: str = pydantic.Field(description="Description of the error code.")

--- a/src/styx/frontend/schema/properties/groups.py
+++ b/src/styx/frontend/schema/properties/groups.py
@@ -1,0 +1,37 @@
+from typing import Annotated, Optional
+
+import pydantic
+
+from .. import StringProperty
+
+
+class Group(pydantic.BaseModel):
+    id: Annotated[
+        str, pydantic.StringConstraints(pattern=r"^[0-9,_,a-z,A-Z]*$", min_length=1)
+    ] = pydantic.Field(
+        description='A short, unique, informative identifier containing only alphanumeric characters and underscores. Typically used to generate variable names. Example: "outfile_group".',
+    )
+    name: StringProperty = pydantic.Field(
+        description="A human-readable name for the input group."
+    )
+    description: Optional[str] = pydantic.Field(
+        description="Description of the input group.", default=None
+    )
+    members: list[
+        Annotated[str, pydantic.StringConstraints(pattern=r"^[0-9,_,a-z,A-Z]*$")]
+    ] = pydantic.Field(description="IDs of the inputs belonging to this group.")
+    mutually_exclusive: bool = pydantic.Field(
+        alias="mutually-exclusive",
+        description="True if only one input in the group may be active at runtime.",
+        default=False,
+    )
+    one_is_required: bool = pydantic.Field(
+        alias="one-is-required",
+        description="True if at least one of the inputs in the group must be active at runtime.",
+        default=False,
+    )
+    all_or_one: bool = pydantic.Field(
+        alias="all-or-none",
+        description="True if members of the group need to be toggled together",
+        default=False,
+    )

--- a/src/styx/frontend/schema/properties/io.py
+++ b/src/styx/frontend/schema/properties/io.py
@@ -1,0 +1,257 @@
+from typing import Annotated, Any, Literal, Optional, Self, Union
+
+import pydantic
+
+from .. import StringProperty
+from .groups import Group
+
+
+class IOModel(pydantic.BaseModel):
+    """Base input / output model."""
+
+    id: Annotated[
+        str, pydantic.StringConstraints(pattern=r"^[0-9,_,a-z,A-Z]*$", min_length=1)
+    ] = pydantic.Field(
+        description='A short, unique, informative identifier containing only alphanumeric characters and underscores. Typically used to generate variable names. Example: "data_file".',
+    )
+    name: StringProperty = pydantic.Field(
+        description="A human-readable name. Example: 'Data file'.",
+    )
+    description: Optional[str] = pydantic.Field(default=None)
+    list_: bool = pydantic.Field(
+        alias="list",
+        description='True if list of values. If value is of type "Flag" cannot be a list.',
+        default=False,
+    )
+    optional: bool = pydantic.Field(description="True if optional", default=False)
+    command_line_flag: Optional[str] = pydantic.Field(
+        alias="command-line-flag",
+        description='Option flag, involved in the value-key substitution. Inputs of type "Flag" have to have a command-line flag. Examples: -v, --force.',
+        default=None,
+    )
+    command_line_flag_separator: Optional[str] = pydantic.Field(
+        alias="command-line-flag-separator",
+        description="Separator used between flags and their arguments. Defaults to a single space.",
+        default=None,
+    )
+    uses_absolute_path: bool = pydantic.Field(
+        alias="uses-absolute-path",
+        description="Specifies value must be given as an absolute path.",
+        default=False,
+    )
+
+    @pydantic.model_validator(mode="after")
+    def validate_dependencies(self) -> Self:
+        if self.command_line_flag_separator and not self.command_line_flag:
+            raise ValueError(
+                "'command-line-flag-separator' requires 'command-line-flag"
+            )
+        return self
+
+
+class SubInput(pydantic.BaseModel):
+    """Model for complex input type with sub-command details."""
+
+    id: Annotated[str, pydantic.StringConstraints(pattern=r"^[0-9,_,a-z,A-Z]+$")]
+    name: str
+    description: Optional[str] = pydantic.Field(default=None)
+    command_line: Optional[str] = pydantic.Field(alias="command-line", default=None)
+    inputs: Optional[list["Input"]] = pydantic.Field(
+        description="An array of input objects.", default=None
+    )
+    output_files: Optional[list[dict[str, Any]]] = pydantic.Field(
+        alias="output-files", default=None
+    )
+    groups: Optional[list[Group]] = pydantic.Field(default=None)
+
+
+class Input(IOModel):
+    """Model representing a Boutiques input."""
+
+    type_: Union[
+        Literal["String", "File", "Flag", "Number"], SubInput, list[SubInput]
+    ] = pydantic.Field(alias="type")
+    list_separator: Optional[str] = pydantic.Field(
+        alias="list-separator",
+        description="Separator used between list items. Defaults to a single space.",
+        default=None,
+    )
+    requires_inputs: Optional[list[str]] = pydantic.Field(
+        alias="requires-inputs",
+        description="Ids of the inputs or ids of groups whose members must be active for this input to be available.",
+        default=None,
+    )
+    disables_inputs: Optional[list[str]] = pydantic.Field(
+        alias="disables-inputs",
+        description="Ids of the inputs that are disabled when this input is active.",
+        default=None,
+    )
+    value_choices: Optional[list[Union[str, int]]] = pydantic.Field(
+        alias="value-choices",
+        description="Permitted choices for input value. May not be used with the Flag type.",
+        default=None,
+    )
+    value_key: str = pydantic.Field(
+        alias="value-key",
+        description="A string contained in command-line, substituted by the input value and/or flag at runtime.",
+    )
+    value_requires: Optional[Any] = pydantic.Field(
+        description="Ids of the inputs that are required when the corresponding value choice is selected.",
+        default=None,
+        deprecated=True,
+    )
+    value_enables: Optional[Any] = pydantic.Field(
+        description="Ids of the inputs that are enabled when the corresponding value choice is selected.",
+        default=None,
+        deprecated=True,
+    )
+    value_disables: Optional[Any] = pydantic.Field(
+        description="Ids of the inputs that are disabled when the corresponding value choice is selected.",
+        default=None,
+        deprecated=True,
+    )
+    integer: bool = pydantic.Field(
+        description="Specify whether the input should be an integer. May only be used with Number type inputs.",
+        default=False,
+    )
+    minimum: Optional[float] = pydantic.Field(
+        description="Specify the minimum value of the input (inclusive). May only be used with Number type inputs.",
+        default=None,
+    )
+    maximum: Optional[float] = pydantic.Field(
+        description="Specify the maximum value of the input (inclusive). May only be used with Number type inputs.",
+        default=None,
+    )
+    exclusive_minimum: bool = pydantic.Field(
+        alias="exclusive-minimum",
+        description="Specify whether the minimum is exclusive or not. May only be used with Number type inputs.",
+        default=False,
+    )
+    exclusive_maximum: bool = pydantic.Field(
+        alias="exclusive-maximum",
+        description="Specify whether the maximum is exclusive or not. May only be used with Number type inputs.",
+        default=False,
+    )
+    min_list_entries: Optional[float] = pydantic.Field(
+        alias="min-list-entries",
+        description="Specify the minimum number of entries in the list. May only be used with List type inputs.",
+        default=None,
+    )
+    max_list_entries: Optional[float] = pydantic.Field(
+        alias="max-list-entries",
+        description="Specify the maximum number of entries in the list. May only be used with List type inputs.",
+        default=None,
+    )
+    resolve_parent: bool = pydantic.Field(
+        alias="resolve-parent",
+        description="Specifies that the full parent directory of this file needs to be visible to the tool. Only specifiable for File type inputs.",
+        default=False,
+    )
+    mutable: bool = pydantic.Field(
+        description="Specifies that the tool may modify the input file. Only specifiable for File type inputs.",
+        default=False,
+    )
+
+    @pydantic.field_validator("type_")
+    def validate_type(cls, v):
+        """Validate input type constraints."""
+        if isinstance(v, str) and v not in ["String", "File", "Flag", "Number"]:
+            raise ValueError(f"Invalid input type: {v}")
+        return v
+
+    @pydantic.model_validator(mode="after")
+    def validate_dependencies(self) -> Self:
+        if self.type_ == "Flag" and self.list_:
+            raise ValueError("'list' cannot be true when input is of type 'Flag'")
+
+        def _raise_field_error(field: str, condition: str):
+            """Helper to raise field-related errors."""
+            raise ValueError(f"Field '{field}' {condition}")
+
+        if not self.list_:
+            if self.min_list_entries is not None or self.max_list_entries is not None:
+                _raise_field_error(
+                    "min_list_entries / max_list_entries",
+                    "can only be set if 'list' is true.",
+                )
+            if self.list_separator:
+                _raise_field_error(
+                    "list_separator", "can only be set if 'list_' is true."
+                )
+
+        if self.type_ != "Number":
+            if self.minimum is not None or self.maximum is not None:
+                _raise_field_error(
+                    "minimum / maximum ",
+                    "can only be set if 'type' is 'Number'.",
+                )
+
+        if self.uses_absolute_path and self.type_ != "File":
+            _raise_field_error(
+                "uses_absolute_path", "can only be set if 'type' is 'File'."
+            )
+
+        for excl_field, bound_field in [
+            (self.exclusive_minimum, self.minimum),
+            (self.exclusive_maximum, self.maximum),
+        ]:
+            if excl_field and bound_field is None:
+                _raise_field_error(
+                    "exclusive_minimum / exclusive_maximum",
+                    "can only be set if minimum / maximum are provided.",
+                )
+
+        return self
+
+
+class PathProperty(pydantic.BaseModel):
+    """Model representing an path property."""
+
+    propertyNames: Annotated[
+        str, pydantic.StringConstraints(pattern=r"^[A-Za-z0-9_><=!)( ]*$")
+    ] = pydantic.Field(default=None)
+
+
+class Output(IOModel):
+    """Model representing an output file."""
+
+    path_template: Optional[StringProperty] = pydantic.Field(
+        alias="path-template",
+        description='Describes the output file path relatively to the execution directory. May contain input value keys and wildcards. Example: "results/[INPUT1]_brain*.mnc".',
+        default=None,
+    )
+    conditional_path_template: Optional[list[PathProperty]] = pydantic.Field(
+        alias="conditional-path-template",
+        description='List of objects containing boolean statement (Limited python syntax: ==, !=, <, >, <=, >=, and, or) and output file paths relative to the execution directory, assign path of first true boolean statement. May contain input value keys, "default" object required if "optional" set to True . Example list: "[{"[PARAM1] > 8": "outputs/[INPUT1].txt"}, {"default": "outputs/default.txt"}]".',
+        min_length=1,
+        default=None,
+    )
+    path_template_stripped_extensions: Optional[list[str]] = pydantic.Field(
+        alias="path-template-stripped-extensions",
+        description='List of file extensions that will be stripped from the input values before being substituted in the path template. Example: [".nii",".nii.gz"].',
+        default=None,
+    )
+    file_template: Optional[list[StringProperty]] = pydantic.Field(
+        alias="file-template",
+        description="An array of strings that may contain value keys. Each item will be a line in the configuration file.",
+        default=None,
+    )
+    value_key: Optional[str] = pydantic.Field(
+        alias="value-key",
+        description="A string contained in command-line, substituted by the input value and/or flag at runtime.",
+        default=None,
+    )
+
+    @pydantic.model_validator(mode="after")
+    def validate_dependencies(self) -> Self:
+        if self.path_template and self.conditional_path_template:
+            raise ValueError(
+                "Only one of 'path-template' or 'conditional-path-template' should be set."
+            )
+
+        if isinstance(self.file_template, list) and self.list_:
+            raise ValueError(
+                "If file-template' is a list, 'list' parameter should be False"
+            )
+
+        return self

--- a/src/styx/frontend/schema/properties/resources.py
+++ b/src/styx/frontend/schema/properties/resources.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+import pydantic
+
+
+class SuggestedResources(pydantic.BaseModel):
+    """Model for suggested computational resources."""
+
+    cpu_cores: Optional[int] = pydantic.Field(
+        alias="cpu-core",
+        description="The requested number of cpu cores to run the described application",
+        ge=1,
+    )
+    ram: Optional[float] = pydantic.Field(
+        description="The requested number of GB RAM to run the described application",
+        ge=0,
+    )
+    disk_space: Optional[float] = pydantic.Field(
+        alias="disk-space",
+        description="The requested number of GB of storage to run the described application",
+        ge=0,
+    )
+    nodes: Optional[int] = pydantic.Field(
+        description="The requested number of nodes to spread the described application across",
+        ge=1,
+    )
+    walltime_estimate: Optional[float] = pydantic.Field(
+        alias="walltime-estimate",
+        description="Estimated wall time of a task in seconds.",
+        ge=0,
+    )

--- a/src/styx/frontend/schema/properties/tests.py
+++ b/src/styx/frontend/schema/properties/tests.py
@@ -1,0 +1,32 @@
+from typing import Annotated, Any, Optional
+
+import pydantic
+
+from .. import StringProperty
+
+
+class OutputFile(pydantic.BaseModel):
+    id: Annotated[
+        str, pydantic.StringConstraints(pattern=r"^[0-9,_,a-z,A-Z]*$", min_length=1)
+    ] = pydantic.Field(description="Id referring to an output-file")
+    md5_reference: Optional[str] = pydantic.Field(
+        alias="md5-reference",
+        description="MD5 checksum string to match against the MD5 checksum of the output-file specified by the id object",
+        min_length=1,
+        default=None,
+    )
+
+
+class Assertion(pydantic.BaseModel):
+    exit_code: int = pydantic.Field(
+        alias="exit-code", description="Expected code returned by the program."
+    )
+    output_files: list[OutputFile] = pydantic.Field(alias="output-files", min_length=1)
+
+
+class TestCase(pydantic.BaseModel):
+    """Model for test cases."""
+
+    name: StringProperty = pydantic.Field(description="Name of the test-case")
+    invocation: dict[str, Any]
+    assertions: Assertion


### PR DESCRIPTION
An initial pydantic model that tried to mimic the descriptor schema found in [`niwrap`](https://github.com/childmindresearch/niwrap). Tested it locally against some descriptors and those have passed. Still needs a little work to integrate with the core. 

Some additional notes:
- Wrapping the validation with try-except ends up with more helpful error messages (at least when developing).
- Might be missing some validation logic
- Briefly discussed writing two base model classes and using `Union` for `oneOf` cases (from the descriptor).